### PR TITLE
First version of the dockerfiles

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:current-alpine
+
+COPY package*.json ./
+RUN npm install --legacy-peer-deps
+COPY . .
+
+EXPOSE 80
+
+CMD [ "npm", "run", "build" ]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:current-alpine
+
+WORKDIR /server
+
+COPY package*.json ./
+RUN npm install --legacy-peer-deps
+COPY . .
+RUN npm run build
+
+EXPOSE 8080
+
+CMD [ "node", "build/server.js" ]


### PR DESCRIPTION
Closes #45 

Following the principle of single responisbility, server and client get a Dockerfile each that can later be used in a docker compose.

Since i didn't fully understand the application i strongly suggest a verification in the client Dockerfile for the deployment (i followed the documentation) and for the exposed port (change port 80 and/or 8080 to the desired port used by this application)

I'm here if there is any questions! Thanks