### PR TITLE
Addresses #80 "Update Search Functionality to Accommodate Riot IDs". 

### DIFF
--- a/client/src/components/Form/SearchForm.vue
+++ b/client/src/components/Form/SearchForm.vue
@@ -148,7 +148,7 @@ export default {
       document.body.style.overflow = 'hidden'
     },
     formSubmit() {
-      const search = this.summoner.split(' ').join('').replace('+', ' ')
+      const search = this.summoner.split(' ').join('').replace('+', ' ').replace('#', '-')
       if (search.length) {
         this.$emit('formSubmit', search, this.selectedRegion)
       }

--- a/server/app/Controllers/Http/SummonersController.ts
+++ b/server/app/Controllers/Http/SummonersController.ts
@@ -35,7 +35,31 @@ export default class SummonersController {
     const { summoner, region } = await request.validate(SummonerBasicValidator)
 
     try {
-      const account = await SummonerService.getAccount(summoner, region)
+      // Coming from C++ this seems completely fine. Which suggests to me that it likely isn't.
+      var account
+
+      // Checks if searching for Riot tag. Frontend is currently replacing `#` with `-`.
+      if (!summoner.includes(`-`)) {
+        account = await SummonerService.getAccount(summoner, region)
+      } else {
+        const [name, tagline] = summoner.split(`-`)
+        account = await SummonerService.getRiotAccountByName(name, tagline, region)
+        if (!account) {
+          return response.json(null)
+        }
+
+        const additionalInfo = await SummonerService.getSummonerByPuuid(account.puuid, region)
+
+        if (!additionalInfo) {
+          return response.json(null)
+        }
+
+        account = {
+          ...account,
+          ...additionalInfo,
+        }
+      }
+
       // Check if the summoner is found
       if (!account) {
         return response.json(null)

--- a/server/app/Services/Jax/src/Endpoints/SummonerEndpoint.ts
+++ b/server/app/Services/Jax/src/Endpoints/SummonerEndpoint.ts
@@ -2,6 +2,7 @@
 import RiotRateLimiter from 'riot-ratelimiter'
 import { JaxConfig } from '../../JaxConfig'
 import JaxRequest from '../JaxRequest'
+import { getRiotRegion } from 'App/helpers'
 
 export interface SummonerDTO {
   accountId: string
@@ -47,6 +48,27 @@ export default class SummonerEndpoint {
       region,
       this.config,
       `summoner/v4/summoners/by-name/${encodeURI(summonerName)}`,
+      this.limiter,
+      36000
+    ).execute()
+  }
+
+  public puuidFromRiotTag(name: string, tagline: string, region: string): Promise<SummonerDTO> {
+    return new JaxRequest(
+      getRiotRegion(region),
+      this.config,
+      `account/v1/accounts/by-riot-id/${name}/${tagline}`,
+      this.limiter,
+      36000,
+      `riot`
+    ).execute()
+  }
+
+  public summonerPuuid(puuid: string, region: string): Promise<SummonerDTO> {
+    return new JaxRequest(
+      region,
+      this.config,
+      `summoner/v4/summoners/by-puuid/${puuid}`,
       this.limiter,
       36000
     ).execute()

--- a/server/app/Services/Jax/src/JaxRequest.ts
+++ b/server/app/Services/Jax/src/JaxRequest.ts
@@ -12,6 +12,7 @@ export default class JaxRequest {
   private limiter: RiotRateLimiter
   private cacheTime: number
   private retries: number
+  private riotApiPath: string
   private sleep: { (ms: number): Promise<void>; <T>(ms: number, value: T): Promise<T> }
 
   constructor(
@@ -19,7 +20,8 @@ export default class JaxRequest {
     config: JaxConfig,
     endpoint: string,
     limiter: RiotRateLimiter,
-    cacheTime: number
+    cacheTime: number,
+    riotApiPath = `lol`
   ) {
     this.region = region
     this.config = config
@@ -27,12 +29,13 @@ export default class JaxRequest {
     this.limiter = limiter
     this.cacheTime = cacheTime
     this.retries = config.requestOptions.retriesBeforeAbort
+    this.riotApiPath = riotApiPath
 
     this.sleep = promisify(setTimeout)
   }
 
   public async execute() {
-    const url = `https://${this.region}.api.riotgames.com/lol/${this.endpoint}`
+    const url = `https://${this.region}.api.riotgames.com/${this.riotApiPath}/${this.endpoint}`
 
     // Redis cache
     if (this.cacheTime > 0) {

--- a/server/app/Services/SummonerService.ts
+++ b/server/app/Services/SummonerService.ts
@@ -63,6 +63,14 @@ class SummonerService {
     return account
   }
 
+  public async getRiotAccountByName(name: string, tagline: string, region: string) {
+    return await Jax.Summoner.puuidFromRiotTag(name, tagline, region)
+  }
+
+  public async getSummonerByPuuid(puuid: string, region: string) {
+    return await Jax.Summoner.summonerPuuid(puuid, region)
+  }
+
   /**
    * Return the full list of old and actual summoner names
    * @param account of the summoner

--- a/server/app/Validators/SummonerBasicValidator.ts
+++ b/server/app/Validators/SummonerBasicValidator.ts
@@ -24,7 +24,7 @@ export default class SummonerBasicValidator {
    *    ```
    */
   public schema = schema.create({
-    summoner: schema.string({}, [rules.regex(/^[0-9\p{L} _\.]+$/u)]),
+    summoner: schema.string({}, [rules.regex(/^[0-9\p{L} _\.-]+$/u)]),
     region: schema.string(),
   })
 


### PR DESCRIPTION
- Check in `SummonersController` per @vkaelin's comment on issue https://github.com/vkaelin/LeagueStats/issues/80
- - Had to send an additional request to get account id after retrieving puuid by gameName/tagline
- `puuidFromRiotTag(name, tagline, string, region)` in SummonerEndpoint
- `summonerPuuid(puuid, region)` in SummonerEndpoint
- Modified `JaxRequest` constructor to take default parameter `riotApiPath`.
- - This is due to `JaxRequest` previously assuming the api subpath of `/lol/`. `AccountsV1` is located at `/riot/`.
- Adjusted `SummonerBasicValidator` schema to accept `-` in input.
- Modify frontend `SearchForm` to replace `#` with `-` to avoid having to encode `#` which would result in ugly urls.

I've never worked with Vue and don't frequently work with frontend in general. If any of these changes aren't up to par I'd be happy to revisit them. 